### PR TITLE
scripts: add pre-commit git hook to run git-clang-format

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Copyright 2022 Meta
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+FILES="$(git diff --cached --name-only)"
+
+for F in $FILES; do
+  BN="$(basename $F)"
+
+  if [ "$(basename $BN .sh)" != "$BN" ]; then
+    # clang-format does not seem to process .sh files properly
+    continue
+  fi
+
+  clang-format -i --style=file $F
+  git add $F
+done


### PR DESCRIPTION
scripts: add pre-commit git hook to run clang-format

In order to increase SNR in pull requests, contributors should run:
```
cp scripts/pre-commit.sh .git/hooks/pre-commit
chmod +x .git/hooks/pre-commit
```

Then, whitespace and other common formatting issues are resolved prior to commit. Note: `.sh` files do not seem to be formatted properly by `clang-format`, so those are skipped.

Fixes #109