### PR TITLE
samples: thrift: hello: use int main instead of void main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         shell: bash
         run: |
           source zephyr-env.sh
-          twister -i --build-only -W -T samples/
+          twister -i --build-only -G -T samples/
 
       - name: Build Samples (POSIX)
         working-directory: thrift-for-zephyr

--- a/samples/lib/thrift/hello_client/sample.yaml
+++ b/samples/lib/thrift/hello_client/sample.yaml
@@ -2,22 +2,18 @@ sample:
   description: Hello Thrift sample
   name: hello thrift
 common:
-  tags: samples thrift cpp
+  tags: thrift cpp
   # FIXME: zephyrproject-rtos/zephyr#45100
   arch_exclude: posix
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
+  toolchain_exclude: xcc
+  arch_exclude: arc xtensa
+  integration_platforms:
+    - mps2_an385
+    - qemu_x86_64
 tests:
   thrift.hello.newlib:
-    filter: TOOLCHAIN_HAS_NEWLIB == 1
-    toolchain_exclude: xcc
-    platform_exclude: qemu_x86 qemu_leon3 qemu_malta qemu_malta_be
-    arch_exclude: arc xtensa
     tags: newlib
 #  thrift.hello.native:
 #    arch_allow: posix
 #    tags: native
-  thrift.hello.arcmwdtlib:
-    toolchain_allow: arcmwdt
-    platform_allow: nsim_hs nsim_em
-    tags: arc
-    extra_configs:
-      - CONFIG_ARCMWDT_LIBC=y

--- a/samples/lib/thrift/hello_client/src/main.cpp
+++ b/samples/lib/thrift/hello_client/src/main.cpp
@@ -25,7 +25,7 @@ using namespace apache::thrift::protocol;
 using namespace apache::thrift::transport;
 
 #ifdef __ZEPHYR__
-void main(void)
+int main(void)
 #else
 int main(int argc, char** argv)
 #endif
@@ -59,12 +59,8 @@ int main(int argc, char** argv)
     transport->close();
   } catch (std::exception& e) {
     printf("caught exception: %s\n", e.what());
-#ifndef __ZEPHYR__
     return EXIT_FAILURE;
-#endif
   }
 
-#ifndef __ZEPHYR__
   return EXIT_SUCCESS;
-#endif
 }

--- a/samples/lib/thrift/hello_server/sample.yaml
+++ b/samples/lib/thrift/hello_server/sample.yaml
@@ -2,22 +2,18 @@ sample:
   description: Hello Thrift sample
   name: hello thrift
 common:
-  tags: samples thrift cpp
+  tags: thrift cpp
   # FIXME: zephyrproject-rtos/zephyr#45100
   arch_exclude: posix
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
+  toolchain_exclude: xcc
+  arch_exclude: arc xtensa
+  integration_platforms:
+    - mps2_an385
+    - qemu_x86_64
 tests:
   thrift.hello.newlib:
-    filter: TOOLCHAIN_HAS_NEWLIB == 1
-    toolchain_exclude: xcc
-    platform_exclude: qemu_x86 qemu_leon3 qemu_malta qemu_malta_be
-    arch_exclude: arc xtensa
     tags: newlib
 #  thrift.hello.native:
 #    arch_allow: posix
 #    tags: native
-  thrift.hello.arcmwdtlib:
-    toolchain_allow: arcmwdt
-    platform_allow: nsim_hs nsim_em
-    tags: arc
-    extra_configs:
-      - CONFIG_ARCMWDT_LIBC=y

--- a/samples/lib/thrift/hello_server/src/main.cpp
+++ b/samples/lib/thrift/hello_server/src/main.cpp
@@ -25,7 +25,7 @@ using namespace ::apache::thrift::transport;
 using namespace ::apache::thrift::server;
 
 #ifdef __ZEPHYR__
-void main(void)
+int main(void)
 #else
 int main(int argc, char** argv)
 #endif
@@ -55,12 +55,8 @@ int main(int argc, char** argv)
     server.serve();
   } catch (std::exception& e) {
     printf("caught exception: %s\n", e.what());
-#ifndef __ZEPHYR__
     return EXIT_FAILURE;
-#endif
   }
 
-#ifndef __ZEPHYR__
   return EXIT_SUCCESS;
-#endif
 }


### PR DESCRIPTION
After rebasing on a more recent Zephyr release, building the samples failed with an error saying that `main()` should return an `int` rather than `void`.

Fixes #118
