### PR TITLE
lib: thrift: Kconfig: remove nonexistent THRIFT_ZLIB

### DIFF
--- a/lib/thrift/Kconfig
+++ b/lib/thrift/Kconfig
@@ -17,7 +17,6 @@ config THRIFT
 config THRIFT_ZLIB_TRANSPORT
   bool "Enable TZlibTransport support for Thrift"
   depends on THRIFT
-  select THRIFT_ZLIB
   help
     Enable this option to support TZlibTransport for Thrift
 


### PR DESCRIPTION
This was left over from a previous design iteration.
