### PR TITLE
ci: fix build error due to deprecated std::iterator

### DIFF
--- a/lib/thrift/CMakeLists.txt
+++ b/lib/thrift/CMakeLists.txt
@@ -6,9 +6,6 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 set(THRIFT_UPSTREAM "${CMAKE_CURRENT_SOURCE_DIR}/../../.upstream")
 
-# needed in order to expose some C++ class definitions in Newlib
-target_compile_definitions(app PUBLIC _GLIBCXX_HAS_GTHREADS=1)
-
 zephyr_library()
 zephyr_include_directories(include)
 zephyr_include_directories(${THRIFT_UPSTREAM}/lib/cpp/src)
@@ -43,3 +40,6 @@ zephyr_library_sources_ifdef(CONFIG_THRIFT_ZLIB_TRANSPORT
   src/zlib_comp.c
   ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/transport/TZlibTransport.cpp
 )
+
+# needed because std::iterator was deprecated with -std=c++17
+zephyr_library_compile_options(-Wno-deprecated-declarations)

--- a/west.yml
+++ b/west.yml
@@ -14,7 +14,7 @@ manifest:
       remote: cfriedt
       path: thrift-for-zephyr/.upstream
       # corresponds to revision: v0.16.0, but the tag does not exist in cfriedt/thrift
-      revision: 63cad2ee536ead54e6ac75fb5401beb9ab2bbee2
+      revision: b455e5d8e245fbe2568bb28093eb1f7f9d65d442
     - name: net-tools
       remote: zephyrproject-rtos
       revision: master


### PR DESCRIPTION
After switching to Zephyr SDK v0.15.0, we are getting some build warnings that are propogated to errors.

1. `std::iterator` was deprecated in c++17
2. `std::bind` used without including `<functional>`

The `_GLIBCXX_HAS_GTHREADS=1` define is not required until C++ threads are available.

The latter issue is fixed in .upstream