### PR TITLE
ci: fix tests build error due to deprecated std::iterator

### DIFF
--- a/tests/lib/thrift/ThriftTest/CMakeLists.txt
+++ b/tests/lib/thrift/ThriftTest/CMakeLists.txt
@@ -37,3 +37,6 @@ thrift(
 )
 
 target_sources(app PRIVATE ${app_sources})
+
+# needed because std::iterator was deprecated with -std=c++17
+target_compile_options(app PRIVATE -Wno-deprecated-declarations)

--- a/tests/lib/thrift/hello/CMakeLists.txt
+++ b/tests/lib/thrift/hello/CMakeLists.txt
@@ -31,3 +31,6 @@ thrift(
 )
 
 target_sources(app PRIVATE ${app_sources})
+
+# needed because std::iterator was deprecated with -std=c++17
+target_compile_options(app PRIVATE -Wno-deprecated-declarations)


### PR DESCRIPTION
Similar to the previous fix, this is one that is necessary for the tests subdirectory. It's necessary if the library is not built prior to building tests.
