### PR TITLE
ci: separate zephyr and posix builds

### DIFF
--- a/.github/workflows/build-posix.yml
+++ b/.github/workflows/build-posix.yml
@@ -1,0 +1,28 @@
+name: Build (POSIX)
+
+on: [push, pull_request]
+
+jobs:
+  build-posix:
+    defaults:
+      run:
+        shell: bash
+    # Note: ubuntu-latest does not yet have patches for loadCertificateFromBuffer()
+    # Use ubuntu-22.04 until ubuntu-latest is updated
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Update APT package database
+        run: |
+          sudo apt-get update
+
+      - name: Install Thrift
+        run: |
+          sudo apt install -y libboost-all-dev thrift-compiler libthrift-dev
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build Samples (POSIX)
+        run: |
+          make -j -C samples/lib/thrift/hello_client
+          make -j -C samples/lib/thrift/hello_server

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,12 @@
-name: Build
+name: Build (Zephyr)
 
 on: [push, pull_request]
 
 jobs:
   build:
+    defaults:
+      run:
+        shell: bash
     runs-on: ubuntu-latest
     container:
       image: zephyrprojectrtos/ci:latest
@@ -20,19 +23,16 @@ jobs:
 
       - name: Update APT package database
         working-directory: /
-        shell: bash
         run: |
           apt-get update
 
       - name: Install Thrift
         working-directory: /
-        shell: bash
         run: |
           apt install -y libboost-all-dev thrift-compiler libthrift-dev
 
       - name: Initialize Project with West
         working-directory: thrift-for-zephyr
-        shell: bash
         run: |
           pip3 install -U west
           west init -l .
@@ -41,47 +41,12 @@ jobs:
 
       - name: Build and Run Testsuite
         working-directory: thrift-for-zephyr
-        shell: bash
         run: |
           source zephyr-env.sh
           twister -i -G -T tests/
 
       - name: Build Samples
         working-directory: thrift-for-zephyr
-        shell: bash
         run: |
           source zephyr-env.sh
           twister -i --build-only -G -T samples/
-  
-  build-posix:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          path: thrift-for-zephyr
-
-      - name: Update APT package database
-        working-directory: /
-        shell: bash
-        run: |
-          sudo apt-get update
-
-      - name: Install Thrift
-        working-directory: /
-        shell: bash
-        run: |
-          sudo apt install -y libboost-all-dev thrift-compiler libthrift-dev
-
-      - name: Build Samples (POSIX)
-        working-directory: thrift-for-zephyr
-        shell: bash
-        run: |
-          make -j -C samples/lib/thrift/hello_client
-          make -j -C samples/lib/thrift/hello_server
-
-#      - name: Archive firmware
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: firmware
-#          path: thrift-for-zephyr/build/zephyr/zephyr.*


### PR DESCRIPTION
The two builds are independent enough that they can be separate workflows.
