### PR TITLE
post-gsoc changes

### DIFF
--- a/.github/workflows/build-posix.yml
+++ b/.github/workflows/build-posix.yml
@@ -1,6 +1,17 @@
 name: Build (POSIX)
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - v*-branch
+  pull_request:
+    branches:
+      - main
+      - v*-branch
+  schedule:
+    # Run at 00:42 on Thursday and Tuesday
+    - cron: '42 0 * * 4,2'
 
 jobs:
   build-posix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,17 @@
 name: Build (Zephyr)
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - v*-branch
+  pull_request:
+    branches:
+      - main
+      - v*-branch
+  schedule:
+    # Run at 00:42 on Thursday and Tuesday
+    - cron: '42 0 * * 4,2'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Build Status
 
 [![Build](https://github.com/zephyrproject-rtos/gsoc-2022-thrift/actions/workflows/build.yml/badge.svg)](https://github.com/zephyrproject-rtos/gsoc-2022-thrift/actions)
+[![Build (POSIX)](https://github.com/zephyrproject-rtos/gsoc-2022-thrift/actions/workflows/build-posix.yml/badge.svg)](https://github.com/zephyrproject-rtos/gsoc-2022-thrift/actions/workflows/build-posix.yml)
 
 ## What is Thrift?
 

--- a/lib/thrift/src/_stat.c
+++ b/lib/thrift/src/_stat.c
@@ -7,7 +7,7 @@
 #include <errno.h>
 #include <sys/stat.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 int stat(const char* restrict path, struct stat* restrict buf) {
   ARG_UNUSED(path);

--- a/lib/thrift/src/thrift/server/TFDServer.cpp
+++ b/lib/thrift/src/thrift/server/TFDServer.cpp
@@ -14,8 +14,8 @@
 
 #include <thrift/transport/TFDTransport.h>
 
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/zephyr.h>
 
 #include "thrift/server/TFDServer.h"
 

--- a/samples/lib/thrift/hello_client/CMakeLists.txt
+++ b/samples/lib/thrift/hello_client/CMakeLists.txt
@@ -30,3 +30,6 @@ thrift(
 )
 
 target_sources(app PRIVATE ${app_sources})
+
+# needed because std::iterator was deprecated with -std=c++17
+target_compile_options(app PRIVATE -Wno-deprecated-declarations)

--- a/samples/lib/thrift/hello_client/src/main.cpp
+++ b/samples/lib/thrift/hello_client/src/main.cpp
@@ -5,7 +5,7 @@
  */
 
 #ifdef __ZEPHYR__
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #endif
 
 #include <cstdlib>

--- a/samples/lib/thrift/hello_server/CMakeLists.txt
+++ b/samples/lib/thrift/hello_server/CMakeLists.txt
@@ -30,3 +30,6 @@ thrift(
 )
 
 target_sources(app PRIVATE ${app_sources})
+
+# needed because std::iterator was deprecated with -std=c++17
+target_compile_options(app PRIVATE -Wno-deprecated-declarations)

--- a/samples/lib/thrift/hello_server/src/HelloHandler.h
+++ b/samples/lib/thrift/hello_server/src/HelloHandler.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #ifdef __ZEPHYR__
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #else
 #define printk printf
 #endif

--- a/samples/lib/thrift/hello_server/src/main.cpp
+++ b/samples/lib/thrift/hello_server/src/main.cpp
@@ -5,7 +5,7 @@
  */
 
 #ifdef __ZEPHYR__
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #endif
 
 #include <cstdio>


### PR DESCRIPTION
* use `zephyr/kernel.h` since `zephyr/zephyr.h` was deprecated in zephyrproject-rtos/zephyr#49510
* samples: `hello_client` + `hello_server`: `std::iterator` fixup similar to #142 
* README: add build status badge for `build-posix.yml`
* ci: add workflow for nightly cron builds
