### PR TITLE
README: build status for both build and build-posix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Build Status
 
 [![Build](https://github.com/zephyrproject-rtos/gsoc-2022-thrift/actions/workflows/build.yml/badge.svg)](https://github.com/zephyrproject-rtos/gsoc-2022-thrift/actions)
+[![Build (POSIX)](https://github.com/zephyrproject-rtos/gsoc-2022-thrift/actions/workflows/build-posix.yml/badge.svg)](https://github.com/zephyrproject-rtos/gsoc-2022-thrift/actions/workflows/build-posix.yml)
 
 ## What is Thrift?
 


### PR DESCRIPTION
Since separating `build-posix.yaml` from `build.yaml`, it is necessary to provide badgest for both to indicate the current build status.