### PR TITLE
github: workflows: add daily cron build

### DIFF
--- a/.github/workflows/build-posix.yml
+++ b/.github/workflows/build-posix.yml
@@ -1,6 +1,17 @@
 name: Build (POSIX)
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - v*-branch
+  pull_request_target:
+    branches:
+      - main
+      - v*-branch
+  schedule:
+    # Run at 00:42 on Thursday and Tuesday
+    - cron: '42 0 * * 4,2'
 
 jobs:
   build-posix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,17 @@
 name: Build (Zephyr)
 
 on: [push, pull_request]
+  push:
+    branches:
+      - main
+      - v*-branch
+  pull_request_target:
+    branches:
+      - main
+      - v*-branch
+  schedule:
+    # Run at 00:42 on Thursday and Tuesday
+    - cron: '42 0 * * 4,2'
 
 jobs:
   build:


### PR DESCRIPTION
In the case that upstream (Zephyr or Thrift) introduce a change that breaks downstream, there was previously no event triggered.

Add a scheduled run for `build` and `build-posix` so that we are notified that a build fails.
