### PR TITLE
submanifest: use built-in support for git submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,12 @@ manifest:
   remotes:
     - name: upstream
       url-base: https://github.com/zephyrproject-rtos
-    - name: cfriedt
-      url-base: https://github.com/cfriedt
 
   projects:
     - name: gsoc-2022-thrift
       path: modules/lib/thrift
       revision: main
-    - name: thrift
-      remote: cfriedt
-      path: modules/lib/thrift/.upstream
+      submodules: true
 EOF
 west update
 ```

--- a/scripts/99-thrift.yaml
+++ b/scripts/99-thrift.yaml
@@ -5,13 +5,9 @@ manifest:
   remotes:
     - name: upstream
       url-base: https://github.com/zephyrproject-rtos
-    - name: cfriedt
-      url-base: https://github.com/cfriedt
 
   projects:
     - name: gsoc-2022-thrift
       path: modules/lib/thrift
       revision: main
-    - name: thrift
-      remote: cfriedt
-      path: modules/lib/thrift/.upstream
+      submodules: true


### PR DESCRIPTION
Previously, when the project was structured as a downstream application, we needed to do some extra legwork to get the top-level git submodules to be pulled in, because it is not supported in west. Since then, we've switched to using submanifests, and git submodules are directly supported.

No need to manually specify submodules as west repos.
