### PR TITLE
ci: only update required modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,11 +57,12 @@ jobs:
           submodules: recursive
           path: zephyrproject/modules/lib/thrift
 
-      # This might not even be necessary - please experiment
       - name: Add Thrift Submanifest
+        # Note: this is manually cloned above, but the submanifest
+        # must be there for west to automatically include the module.
+        # Users should use cat << EOF here as shown in README.md.
         working-directory: zephyrproject/zephyr
         shell: bash
-        # users should use cat << EOF here as shown in docs
         run: |
           cp ../modules/lib/thrift/scripts/99-thrift.yaml submanifests
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,17 @@ jobs:
     container:
       image: zephyrprojectrtos/ci:latest
     env:
-      THRIFT_VERSION: 0.16.0
       CMAKE_PREFIX_PATH: /opt/toolchains
       # To prevent apt from prompting the user to enter locale info
       DEBIAN_FRONTEND: noninteractive
+      # Update west modules minimally for CI
+      # Note the --group-filter argument is still not really useful because
+      # - it pulls in way too much by default
+      #   - many modules do not belong to a group
+      #   - the default is to include all modules
+      # - it is impossible to start a group filter with a dash e.g. -debug
+      # For reference: west update --group-filter +crypto,-debug,-fs,-hal,-tee,-tools
+      WEST_MODULES: cmsis mbedtls
     steps:
       - name: Update APT package database
         working-directory: /
@@ -42,7 +49,7 @@ jobs:
           pip3 install -U west
           west init zephyrproject
           cd zephyrproject
-          west update
+          west update $WEST_MODULES
 
       - name: Checkout Thrift Module
         uses: actions/checkout@v2


### PR DESCRIPTION
A huge amount of time is spent in CI updating unnecessary modules.

The TSC previously voted on a `--group-filter` option for `west update`. However, it is currently not very effective because
- `--group-filter` pulls in way too much by default
  - many modules do not belong to a group
  - the default is to include all modules
- it is also not possible to start a group filter subtractively (e.g. `-debug`)

Thrift only depends on 2 modules currently so simply update them individually:
- `cmsis`: all ARM targets (even qemu) require this
- `mbedtls`: required for `TSSLSocket`