### PR TITLE
cmake: use ZEPHYR_THRIFT_MODULE_DIR

### DIFF
--- a/lib/thrift/CMakeLists.txt
+++ b/lib/thrift/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
-set(THRIFT_UPSTREAM "${CMAKE_CURRENT_SOURCE_DIR}/../../.upstream")
+set(THRIFT_UPSTREAM "${ZEPHYR_THRIFT_MODULE_DIR}/.upstream")
 
 zephyr_library()
 zephyr_include_directories(include)

--- a/samples/lib/thrift/hello_client/CMakeLists.txt
+++ b/samples/lib/thrift/hello_client/CMakeLists.txt
@@ -9,7 +9,7 @@ FILE(GLOB app_sources
     src/*.cpp
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../cmake/thrift.cmake)
+include(${ZEPHYR_THRIFT_MODULE_DIR}/cmake/thrift.cmake)
 
 set(generated_sources "")
 set(gen_dir ${ZEPHYR_BINARY_DIR}/misc/generated/thrift_hello)
@@ -23,8 +23,7 @@ thrift(
     cpp
     :no_skeleton
     ${gen_dir}
-    # FIXME: is there a variable that can be used here to refer to the module root?
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../thrift/hello.thrift"
+    "${ZEPHYR_THRIFT_MODULE_DIR}/thrift/hello.thrift"
     ""
     ${generated_sources}
 )

--- a/samples/lib/thrift/hello_server/CMakeLists.txt
+++ b/samples/lib/thrift/hello_server/CMakeLists.txt
@@ -9,7 +9,7 @@ FILE(GLOB app_sources
     src/*.cpp
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../cmake/thrift.cmake)
+include(${ZEPHYR_THRIFT_MODULE_DIR}/cmake/thrift.cmake)
 
 set(generated_sources "")
 set(gen_dir ${ZEPHYR_BINARY_DIR}/misc/generated/thrift_hello)
@@ -23,8 +23,7 @@ thrift(
     cpp
     :no_skeleton
     ${gen_dir}
-    # FIXME: is there a variable that can be used here to refer to the module root?
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../thrift/hello.thrift"
+    "${ZEPHYR_THRIFT_MODULE_DIR}/thrift/hello.thrift"
     ""
     ${generated_sources}
 )

--- a/tests/lib/thrift/ThriftTest/CMakeLists.txt
+++ b/tests/lib/thrift/ThriftTest/CMakeLists.txt
@@ -5,9 +5,9 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(thrift_test)
 
-set(THRIFT_UPSTREAM "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.upstream")
+set(THRIFT_UPSTREAM "${ZEPHYR_THRIFT_MODULE_DIR}/.upstream")
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../cmake/thrift.cmake)
+include(${ZEPHYR_THRIFT_MODULE_DIR}/cmake/thrift.cmake)
 
 FILE(GLOB app_sources 
     src/*.cpp
@@ -30,7 +30,6 @@ thrift(
     cpp
     :no_skeleton
     ${gen_dir}
-    # FIXME: is there a variable that can be used here to refer to the module root?
     "${THRIFT_UPSTREAM}/test/ThriftTest.thrift"
     ""
     ${generated_sources}

--- a/tests/lib/thrift/hello/CMakeLists.txt
+++ b/tests/lib/thrift/hello/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(thrift_hello)
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../cmake/thrift.cmake)
+include(${ZEPHYR_THRIFT_MODULE_DIR}/cmake/thrift.cmake)
 
 FILE(GLOB app_sources
     src/*.cpp
@@ -24,8 +24,7 @@ thrift(
     cpp
     :no_skeleton
     ${gen_dir}
-    # FIXME: is there a variable that can be used here to refer to the module root?
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../thrift/hello.thrift"
+    "${ZEPHYR_THRIFT_MODULE_DIR}/thrift/hello.thrift"
     ""
     ${generated_sources}
 )

--- a/tests/lib/thrift/muzic/CMakeLists.txt
+++ b/tests/lib/thrift/muzic/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(muzic_test)
 
-set(MUZIC_BASE "${CMAKE_CURRENT_SOURCE_DIR}/../../../../lib/thrift/")
+set(MUZIC_BASE "${ZEPHYR_THRIFT_MODULE_DIR}/lib/thrift/")
 
 zephyr_include_directories(${MUZIC_BASE}/include)
 


### PR DESCRIPTION
It's useful to be able to reference files relative to the root of the module. Previously, this was not working in CI because of some weird git submodule / west repo hackery.

However, since we're not using a proper submanifest and git submodule, this should work fine.

Noted, `ZEPHYR_CURRENT_MODULE_DIR` was the first choice but does not work reliably (see chre and sof workarounds). The build system automatically generates `ZEPHYR_THRIFT_MODULE_DIR` as well. If the path ever changes it does need to be modified.